### PR TITLE
Bug fix to ensure that turning off Java Features applies to appropriate matlab versisions:

### DIFF
--- a/mrBOLD/Utilities/mrvJavaFeature.m
+++ b/mrBOLD/Utilities/mrvJavaFeature.m
@@ -35,7 +35,7 @@ matlabVersion = version.Version;
 mVersion = str2double(matlabVersion(1:3));
 mMinorVersion = str2double(matlabVersion(3:end));
 
-if ( (mVersion >= 7) && (mMinorVersion < 4)) % version 7, < 7.4
+if ( (mVersion == 7) && (mMinorVersion < 4)) % version 7, < 7.4
     javaFigs = feature('javafigures');
     if ispref('VISTA', 'javaOn') % seems to work diff't for diff't machines
         feature('javafigures', getpref('VISTA', 'javaOn'));


### PR DESCRIPTION
i.e., 7.0-7.4 as intended, rather than versions greater than 7, which would also include version 8. 

this line
if ( (mVersion >= 7) && (mMinorVersion < 4)) % version 7, < 7.4

was changed to
if ( (mVersion == 7) && (mMinorVersion < 4)) % version 7, < 7.4

Hopefully we can soon eliminate all code pertaining to java features in vistasoft. 
