### PR TITLE
Nifti current orientation bug

### DIFF
--- a/fileFilters/nifti/niftiCurrentOrientation.m
+++ b/fileFilters/nifti/niftiCurrentOrientation.m
@@ -32,7 +32,7 @@ imgCorners = [1 1 1 1; imDim(1) 1 1 1; 1 imDim(2) 1 1; imDim(1) imDim(2) 1 1; ..
 volRas = xform*imgCorners';
 volRas = volRas(1:3,:)';
 
-extPtValue = 100 * max(volRas(1:3,1:3));
+extPtValue = 100 * max(max(abs(volRas)));
 extPtPos = extPtValue;
 extPtNeg = -1 * extPtValue;
 


### PR DESCRIPTION
This was a bug originally reported in this pull request: https://github.com/vistalab/vistasoft/pull/26

After some discussion, Bob had the idea to make the maximum value related to the input values in some way. Proposed here is a solution for that. @rfdougherty @tmq010
