### PR TITLE
Update to the versions looked for by mrVista

### DIFF
--- a/mrBOLD/mrVista.m
+++ b/mrBOLD/mrVista.m
@@ -53,8 +53,7 @@ evalin('base','mrGlobals');
 
 % Check Matlab version number
 % Change list after testing Matlab upgrades
-expectedMatlabVersion = {'6' '6.1' '6.5' '6.5.1' '6.5.2' '7.0' ...
-                         '7.0.1' '7.0.4' '7.1' '7.2', '7.3', '7.4', '7.5', '7.6','7.7', '7.9', '7.11', '7.13'};  
+expectedMatlabVersion = {'7.7', '7.8', '7.9', '7.10', '7.11', '7.13', '7.14', '8'};  
 version = ver('Matlab');
 matlabVersion = version.Version;        
 if ~ismember(matlabVersion, expectedMatlabVersion);    % (matlabVersion ~= expectedMatlabVersion)


### PR DESCRIPTION
Added 2012b and removed a lot of the legacy versions for which mrVista will no longer work (because of the use of the HashTable).
