### PR TITLE
A minor fix to mrVista. The version must be 8.0 and not 8.

### DIFF
--- a/mrBOLD/mrVista.m
+++ b/mrBOLD/mrVista.m
@@ -53,7 +53,7 @@ evalin('base','mrGlobals');
 
 % Check Matlab version number
 % Change list after testing Matlab upgrades
-expectedMatlabVersion = {'7.7', '7.8', '7.9', '7.10', '7.11', '7.13', '7.14', '8'};  
+expectedMatlabVersion = {'7.7', '7.8', '7.9', '7.10', '7.11', '7.13', '7.14', '8.0'};  
 version = ver('Matlab');
 matlabVersion = version.Version;        
 if ~ismember(matlabVersion, expectedMatlabVersion);    % (matlabVersion ~= expectedMatlabVersion)


### PR DESCRIPTION
The version number was not properly being recognized as '8', it has now been updated to '8.0'.
