### PR TITLE
Mrinit slicetimes

### DIFF
--- a/mrBOLD/Analysis/EventAnalysis/AdjustSliceTiming.m
+++ b/mrBOLD/Analysis/EventAnalysis/AdjustSliceTiming.m
@@ -50,6 +50,7 @@ tsDir = viewGet(hiddenView,'tSeriesDir',1);
 deltaFrame = sessionGet(mrSESSION,'interFrameTiming',scans(1));
 refSlice   = sessionGet(mrSESSION,'refSlice',scans(1));
 sliceOrder = sessionGet(mrSESSION,'sliceOrder',scans(1));
+
 if isempty(sliceOrder)
     % GUI to  get the slice ordering from the user
     % sliceOrder = [ 2 4 6 8 1 3 5 7 9 10 11 12 14 16 18 20 13 15 17 19];

--- a/mrBOLD/mrInit.m
+++ b/mrBOLD/mrInit.m
@@ -246,12 +246,11 @@ end
 
 % slice timing correction
 if params.sliceTimingCorrection==1
-    if isfield(params, sliceOrder)
-        slices = params.sliceOrder;
-    else
-        slices = []; % Default behavior assumes 1:nSlices
+    if isfield(params, 'sliceOrder') 
+        mrSESSION = sessionSet(mrSESSION, 'sliceorder', params.sliceOrder);
+        saveSession;
     end
-    INPLANE{1} = AdjustSliceTiming(INPLANE{1}, 0, [], slices);
+    INPLANE{1} = AdjustSliceTiming(INPLANE{1}, 0);
     INPLANE{1} = selectDataType(INPLANE{1}, 'Timed');
 end
 


### PR DESCRIPTION
Current behavior is that if you want to do slice-timing correction you need to enter slice-times by hand. This PR allows users to set this by scripting.  
