### PR TITLE
when sto fields do not exist, we must write srow_x, srow_y, srow_z to a ...

### DIFF
--- a/fileFilters/nifti/niftiVista2ni.m
+++ b/fileFilters/nifti/niftiVista2ni.m
@@ -81,9 +81,9 @@ if(~all(niiv.sto_xyz(1:9)==0))
     nii.hdr.hist.srow_y = sto_xyz(2,:);
     nii.hdr.hist.srow_z = sto_xyz(3,:);
 else
-    nii.hdr.hist.srow_x = 0;
-    nii.hdr.hist.srow_y = 0;
-    nii.hdr.hist.srow_z = 0;
+    nii.hdr.hist.srow_x = [0 0 0 0];
+    nii.hdr.hist.srow_y = [0 0 0 0];
+    nii.hdr.hist.srow_z = [0 0 0 0];
 end
   
 % --- nk fields


### PR DESCRIPTION
...vector of 4 zeros rather than one zero otherwise niftiWrite fails
