### PR TITLE
Correct systematic error generated with dtiInitParams.eddyCorrect=-1

### DIFF
--- a/mrDiffusion/dtiInit/dtiInitDir.m
+++ b/mrDiffusion/dtiInit/dtiInitDir.m
@@ -97,8 +97,11 @@ fprintf('Data will be saved to: %s \n',dwDir.subjectDir);
 
 dwDir.bvalsFile        = [dwDir.inBaseDir  '.bval'];
 dwDir.bvecsFile        = [dwDir.inBaseDir  '.bvec'];
-
-dwDir.ecFile           = [dwDir.outBaseDir  '_ecXform.mat'];
+if dwParams.eddyCorrect == -1 
+    dwDir.ecFile       = ''
+else
+    dwDir.ecFile       = [dwDir.outBaseDir  '_ecXform.mat'];
+end
 dwDir.acpcFile         = [dwDir.outBaseDir  '_acpcXform.mat'];
 dwDir.alignedBvecsFile = [dwDir.outBaseDir '.bvecs'];
 dwDir.alignedBvalsFile = [dwDir.outBaseDir '.bvals'];


### PR DESCRIPTION
`dtiInitDir` always set the `ecFile` to a path no matter the value of the `eddyCorrect` parameter set in the `dtiInitParams` structure. As a result the variable `ecFile`, which becomes `ecXformFile` in `dtiRawResample`, is never empty: even with `dtiInitParams.eddyCorrect = -1`, `isempty(ecXformFile)` in `dtiRawResample` (line 58 in code extract below) will evaluate to `False`, the subsequent test will succeed and lead to try loading the unexisting `ecXformFile` (thus generating an error).

```
if(isempty(ecXformFile))
    xform = [];
elseif(ischar(ecXformFile))
    load(ecXformFile);
else
    xform = ecXformFile;
end
```

A simple fix is to set `ecFile` to an empty string in `dtiInitDir` when  `dtiInitParams.eddyCorrect = -1`
