### PR TITLE
Modifing the definition of the bounding box

### DIFF
--- a/mrDiffusion/roi/dtiRoiNiftiFromMat.m
+++ b/mrDiffusion/roi/dtiRoiNiftiFromMat.m
@@ -74,8 +74,7 @@ end
 
 ref   = niftiRead(refImg);
 xform = ref.qto_xyz;
-bb    = [-size(ref.data)/2; size(ref.data)/2-1];
-
+bb = [-(size(ref.data).*ref.pixdim)/2; (size(ref.data).*ref.pixdim)/2-1];
 
 %% Create the roiImg and xForm from the roi 
 [roiImg, imgXform] = dtiRoiToImg(roi,xform,bb);


### PR DESCRIPTION
In an original version, the size of the bounding box depends upon the size of reference image. This code strongly assumes that the reference image is compatible to ACPC space (1mm), and the bounding box is defined on the basis of that.
But this does not always work well, because sometimes reference and target images have different resolutions. 
For example, if the resolution of reference image is lower, it makes a smaller bounding box for target image (defined in ACPC coordinates in mat file). 
At this time, I made a change of bounding box definition; the size of the bounding box is defined by the size of reference image multiplied by pixel size. In this case, the bounding box becomes proper size even though the resolution of reference image is different from ACPC definition (1 mm). 
