### PR TITLE
Now when we initialize a session, we check the orienation of the functio...

### DIFF
--- a/fileFilters/nifti/niftiCreateXform.m
+++ b/fileFilters/nifti/niftiCreateXform.m
@@ -1,4 +1,4 @@
-function [xform] = niftiCreateXform(nii,xformType)
+function [xform, vectorTo] = niftiCreateXform(nii,xformType)
 %Create a specified transform onto the supplied nifti struct. For
 % data in slice format, we specify our output data xform according to
 % certain rules. Our preferred orientation is PRS, but we do not want to
@@ -40,7 +40,8 @@ function [xform] = niftiCreateXform(nii,xformType)
 %
 % RETURNS
 %  Xform matrix in the form a quaternion
-%
+%  vectorTo: string indicating the orientation that will result from
+%            applying the outut xform to the input nifti
 % See also niftiCreateStringInplane
 %
 % Copyright Stanford VistaLab 2013
@@ -48,6 +49,8 @@ function [xform] = niftiCreateXform(nii,xformType)
 xformType = mrvParamFormat(xformType);
 
 xform = zeros(4); %Initialization
+vectorTo = '';    %Initialization
+
 sliceDim = niftiGet(nii,'slicedim');
 if (sliceDim == 0) %Default to a slice dim of 3 if not populated
     sliceDim = 3;
@@ -55,12 +58,9 @@ end %if
 
 switch xformType
     case 'inplane'
-        [vectorFrom, xform] = niftiCurrentOrientation(nii);
-        if ~strcmp(vectorFrom,'PRS')
-            %We don't need to change the transform at all
-            vectorTo = niftiCreateStringInplane(vectorFrom,sliceDim);
-            xform = niftiCreateXformBetweenStrings(vectorFrom,vectorTo);
-        end
+        vectorFrom = niftiCurrentOrientation(nii);
+        vectorTo   = niftiCreateStringInplane(vectorFrom,sliceDim);
+        xform      = niftiCreateXformBetweenStrings(vectorFrom,vectorTo);
         
     otherwise
         warning('vista:niftiError','The supplied transform type was unrecognized. Please try again. Returning empty transform.');

--- a/mrBOLD/GetSet/Session/sessionGet.m
+++ b/mrBOLD/GetSet/Session/sessionGet.m
@@ -113,6 +113,15 @@ switch param
         else error('The field relevant to %s was not found in the session.', param);
         end
         
+    case {'functionalorientation'}
+        % orientation = sessionGet(s,'functional orientation'); 
+        if isfield(s, 'functionals') && isfield(s.functionals, 'orientation')
+            val = s.functionals(1).orientation;
+        else
+            warning('Functional orientation has not been defined')
+            val = [];
+        end
+            
     case {'inplane'}
         % pth = sessionGet(s, 'inplane path');
         % Return the structure of the inplanes data

--- a/mrBOLD/GetSet/Session/sessionMapParameterField.m
+++ b/mrBOLD/GetSet/Session/sessionMapParameterField.m
@@ -38,6 +38,7 @@ if isempty(DictSessionTranslate)
     DictSessionTranslate('functionals') = 'functionals';
     DictSessionTranslate('functionalsslicedim') = 'functionalsslicedim';
     DictSessionTranslate('functionalvoxelsize') = 'functionalvoxelsize';
+    DictSessionTranslate('functionalorientation') = 'functionalorientation';
     DictSessionTranslate('inplane') = 'inplane';
     DictSessionTranslate('inplanepath') = 'inplanepath';
     DictSessionTranslate('interframedelta') = 'interframetiming';

--- a/mrBOLD/GetSet/Session/sessionSet.m
+++ b/mrBOLD/GetSet/Session/sessionSet.m
@@ -56,7 +56,8 @@ switch param
         if isempty(varargin), s.functionals = val;
         else s.functionals(varargin{1}) = val;
         end
-        
+    case {'functionalorientation'}
+        s.functionals(1).orientation = val;        
     case {'inplane'}
         s.inplanes = val;
         % Information about the functional scans

--- a/mrBOLD/GetSet/View/viewGetAnatomy.m
+++ b/mrBOLD/GetSet/View/viewGetAnatomy.m
@@ -37,6 +37,12 @@ switch param
     case 'anatomynifti'
         %Return the actual nifti struct stored in anat
         val = vw.anat;
+    case 'inplaneorientation'
+        %Return the orientation of the inplane as a 3 letter string (e.g.,
+        %'PRS' for Posterior/Right/Superior as indices increase in dims
+        %1-3)
+        if isfield(vw, 'inplaneOrientation'), val = vw.inplaneOrientation; 
+        else warning('Inplane orientation not set'); val = []; end               
     case 'anatclip'
         % Return anatomy clipping values from anatMin and anatMax sliders.
         %   anataomyClip = viewGet(vw, 'Anatomy Clip');

--- a/mrBOLD/GetSet/View/viewGetSession.m
+++ b/mrBOLD/GetSet/View/viewGetSession.m
@@ -99,7 +99,7 @@ switch param
         if isequal(vw.name,'hidden')
             % no UI or slider -- use tSeries slice
             curSlice = vw.tSeriesSlice;
-            if isnan(curSlice) || isempty(curSlice), val = 1; end
+            if isnan(curSlice) | isempty(curSlice), val = 1; end
             return
         end
         switch vw.viewType

--- a/mrBOLD/GetSet/View/viewMapParameterField.m
+++ b/mrBOLD/GetSet/View/viewMapParameterField.m
@@ -154,6 +154,7 @@ if isempty(DictViewTranslate)
     DictViewTranslate('anatnifti') = 'anatomynifti';
     DictViewTranslate('niftianat') = 'anatomynifti';
     DictViewTranslate('niftianatomy') = 'anatomynifti';
+    DictViewTranslate('inplaneorientation') = 'inplaneorientation';    
     DictViewTranslate('anatsizexyz') = 'anatsizexyz';
     DictViewTranslate('anatomysizeforclass') = 'anatsizexyz';
     DictViewTranslate('ngraylayers') = 'ngraylayers';

--- a/mrBOLD/GetSet/View/viewMapParameterSplit.m
+++ b/mrBOLD/GetSet/View/viewMapParameterSplit.m
@@ -18,6 +18,7 @@ if isempty(DictViewSplit)
     DictViewSplit('anatomycurrentslice') = 'anatomy';
     DictViewSplit('anatomymap') =  'anatomy';
     DictViewSplit('anatomynifti') =  'anatomy';
+    DictViewSplit('inplaneorientation') =  'anatomy';
     DictViewSplit('anatsize') =  'anatomy';
     DictViewSplit('anatsizexyz') =  'anatomy';
     DictViewSplit('anatslicedim') =  'anatomy';

--- a/mrBOLD/GetSet/View/viewSet.m
+++ b/mrBOLD/GetSet/View/viewSet.m
@@ -53,6 +53,7 @@ function vw = viewSet(vw,param,val,varargin)
 %      'inplanepath'
 %      'anatinitialize'
 %      'anatomynifti'
+%      'inplaneorientation'
 %
 % %%%%% ROI-related properties
 %      'roi'

--- a/mrBOLD/GetSet/View/viewSetAnatomy.m
+++ b/mrBOLD/GetSet/View/viewSetAnatomy.m
@@ -26,15 +26,24 @@ switch param
         setSlider(vw, vw.ui.contrast, val);
     case 'inplanepath'
         vw.anat.inplanepath = val;
+    case 'inplaneorientation'
+        vw.inplaneOrientation = val;
     case 'anatinitialize'
         %Expects a path as the value
         %Read in the nifti from the path value
         vw = viewSet(vw,'Anatomy Nifti', niftiRead(val));
         %Calculate Voxel Size as that is not read in
         vw = viewSet(vw,'Anatomy Nifti', niftiSet(viewGet(vw,'Anatomy Nifti'),'Voxel Size',prod(niftiGet(vw.anat,'pixdim'))));
-        
-        %Let us also calculate and and apply our transform
-        vw = viewSet(vw,'Anatomy Nifti',niftiApplyAndCreateXform(viewGet(vw,'Anatomy Nifti'),'Inplane'));
+        %If functional orientation is defined, make sure we use it
+        ipOrientation = viewGet(vw, 'Inplane Orientation');
+        if ~isempty(ipOrientation)            
+            vectorFrom = niftiCurrentOrientation(viewGet(vw,'Anatomy Nifti'));
+            xform      = niftiCreateXformBetweenStrings(vectorFrom,ipOrientation);
+            vw = viewSet(vw, 'Anatomy Nifti', niftiApplyXform(viewGet(vw,'Anatomy Nifti'),xform));
+        else
+            %Let us also calculate and and apply our transform
+            vw = viewSet(vw,'Anatomy Nifti',niftiApplyAndCreateXform(viewGet(vw,'Anatomy Nifti'),'Inplane'));
+        end
     case 'anatomynifti'
         vw.anat = val; %This means that we are passing in an entire Nifti!
         

--- a/mrBOLD/Window/openMontageWindow.m
+++ b/mrBOLD/Window/openMontageWindow.m
@@ -161,6 +161,7 @@ INPLANE{s} = eventMenu(INPLANE{s});
 INPLANE{s} = helpMenu(INPLANE{s}, 'Inplane');
 
 % go ahead and load the anatomicals
+INPLANE{s} = viewSet(INPLANE{s}, 'Inplane orientation', sessionGet(mrSESSION,'functional orientation'));
 INPLANE{s} = loadAnat(INPLANE{s}, sessionGet(mrSESSION,'Inplane Path'));
 
 

--- a/mrBOLD/mrInit.m
+++ b/mrBOLD/mrInit.m
@@ -168,6 +168,7 @@ save mrInit_params params   % stash the params in case we crash
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 if isfield(params,'functionals') && ~isempty(params.functionals)
+    if ischar(params.functionals), params.functionals = {params.functionals}; end
     func = mrLoadHeader(params.functionals{1});
     
     for scan = 1:length(params.functionals)
@@ -185,6 +186,11 @@ if isfield(params,'functionals') && ~isempty(params.functionals)
         %local func struct.
         tS = niftiRead(func.path);
         tS = niftiApplyAndCreateXform(tS,'Inplane');
+        
+        %Store the orientation of the functional data. We will need the
+        %anatomical Inplane to have the same orientation.
+        [~, func.orientation] = niftiCreateXform(tS,'Inplane');
+        
         %Need to move over:
         %Data
         func.data = niftiGet(tS,'Data');
@@ -372,7 +378,7 @@ f.reconParams = mr.hdr;
 
 if scan==1
     mrSESSION = sessionSet(mrSESSION, 'Functionals', f);
-    %mrSESSION.functionals = f;
+    mrSESSION = sessionSet(mrSESSION, 'Functional Orientation', mr.orientation);
 else
     mrSESSION = sessionSet(mrSESSION, 'Functionals', ...
         mergeStructures(sessionGet(mrSESSION, 'Functionals', scan-1), f), scan);


### PR DESCRIPTION
...nal scans and store this in mrSESSION, e.g., as LPS. We then use this orientation to ensure that the orientation of the inplane underlay is the same

NOTE: This new branch was tested with validation code (mrvTest). All tests passed. It was also tested with a dataset provided by Lior in which the Inplanes and EPIs had a different orientation. Without this new branch, the initialization produces a mismatched Inplane/Functional registration. With the new branch, the Inplane and functional data are correctly registered. 

Code to test Lior's data (which requires the data sets Lior shared with me):

> cd '~/Downloads/SessionWithProblem_8525/'
> 
> % initialize the session
> params = mrInitDefaultParams;
> 
> params.inplane     = '8525_2_1.nii.gz';
> params.functionals = '8525_4_1.nii.gz';
> params.sessionDir  = pwd;
> 
> ok = mrInit(params);
> 
> % check the EPI/INPLANE alignment
> vw = mrVista;
> vw = loadMeanMap(vw); mnmap = viewGet(vw, 'map');
> vw = setDisplayMode(vw,'map'); 
> vw = viewSet(vw, 'map win', prctile(mnmap{1}(:), [75 100]));
> setSlider(vw,vw.ui.montageSize,'val',viewGet(vw, 'num slices')); 
> vw = refreshScreen(vw);

