### PR TITLE
BF+DOC: Handle file extensions more robustly. Fix the buggy case where a...

### DIFF
--- a/fileFilters/nifti/niftiWrite.m
+++ b/fileFilters/nifti/niftiWrite.m
@@ -1,56 +1,93 @@
 function niftiWrite(ni,fName)
-% Matlab wrapper for writeFileNifti. Writes a nifti structure to disk. 
+%  Writes a nifti structure to disk. 
 %
 %   niftiWrite(ni,[fName])
 %
-% If nifti data are int16, uses the fast mex-file write.  Otherwise it uses
-% the NIFTI-1 implementation in Matlab from Shen. The Matlab implementation
-% preserves NaNs, but the mex-version we implemented fails to preserve
-% them.
+% Uses the NIFTI-1 implementation in Matlab from Shen. 
 % 
 % INPUTS
-%   ni - a nifti file structure 
-%   fName - output file name  (defaults to ni.fname). 
-%
-% Web Resources:
-%   mrvBrowseSVN('niftiWrite');
+%   ni - a nifti structure 
+%   fName - output file name  (defaults to ni.fname if empty). 
 % 
-% Example:
+% FILE FORMATS:
+%   Defaults to compressed '.nii.gz' format. If fName is set to
+%   [something]'.nii' then compression is not performmed as it is presumed
+%   that the user does not want the file to be compressed.
+% 
+% Web Resources:
+%   To browse the latest code on github run: vistaBrowseGit('niftiWrite');
+%
+% EXAMPLE:
 %   ni = niftiRead('niftiFile.nii.gz');
 %   fName = 'myFile.nii.gz'
 %   niftiWrite(ni,fName);
-%
+% 
 % See also:  niftiCreate, feWriteValues2nifti
 % 
-% (C) Stanford VISTA, 2012
+% (C) Stanford VISTA, 2012-2015
+% 
+
+%% Set defaults
+compress = true;
+fname_supplied = false;
 
 
 %% Check inputs
+if nargin==0
+    help(mfilename)
+    return
+end
 
-% If the filename does not include an extension we assign one here.
-if exist('fName','var'),  ni.fname = fName; end
-[p f e] = fileparts(ni.fname);
-if isempty(e), ni.fname = fullfile(p,[f '.nii.gz']); end
+if notDefined('fName')
+    fName = '';
+else
+    fname_supplied = true;
+end
+
+
+%% Check file extension
+
+% If no name was supplied check the nifti structure for the name
+if isempty(fName)
+    if isfield(ni,'fname') && ~isempty(ni.fname)
+        fName = ni.fname;
+    else
+        error('A filename is required to save a NIFTI-1 structure to file.');
+    end
+end
+    
+% Handle the file extension (must be '.nii' for save_nii)
+[p, f, e] = fileparts(fName);
+switch e
+    case '.gz'
+        fName = fullfile(p,f);
+    case '.nii'
+        % If a filename was passed in and it was something'.nii' then we
+        % assume the user does not want the file compressed.
+        if fname_supplied; compress = false; end
+    otherwise
+        fName = fullfile(p,[f '.nii']);
+end
+
 
 %% Deal with old VISTASOFT nifti structures.
 if isfield(ni,'data')
   % This is likely to be a old VISTASOFT nifti-1 structure, see
   % niftiVista2ni.m
-  if notDefined('fileName'), fileName = ni.fname;end
   ni = niftiVista2ni(ni);
 end
 
+
 %% Save the file to disk using Shen's code.
-if notDefined('fileName'), error('File name necessary to save a NIFTI-1 structure to file.');end
-[p,n,e] = fileparts(fileName);
-if isempty(e), n = sprintf('%s.nii',n);end
-save_nii(ni,fullfile(p,n));
-
-%% Zip the file
-gzip(fullfile(p,n));
-
-%% Delete the unzipped file created by save_nii.m:
-delete(fullfile(p,n));
+save_nii(ni,fName);
 
 
+%% GZip the file
+if compress
+    gzip(fName);
+     
+    % Delete the unzipped file created by save_nii.m:
+    delete(fName);
 end
+
+return


### PR DESCRIPTION
... '.nii' extension is passed in as an output filename. Make gzip compression the default but not force if the filename passed in was '.nii' - in that case simply leave the file uncompressed. 