### PR TITLE
Cleaned up the README.md and added Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,20 @@ For detailed documentation, please visit the [VISTA lab wiki](http://vistalab.st
 To install Vistasoft:
 
 1. Clone the Vistasoft repository on your local machine; for example:
-       ```sh
-       > cd ~/matlab
-       > git clone https://github.com/vistalab/vistasoft
-       ```
+
+   ```sh
+   > cd ~/matlab
+   > git clone https://github.com/vistalab/vistasoft
+
+   ```
+   
 2. Start Matlab and Add the Vistasoft repository's base directory to your Matlab path:
-       ```matlab
-       addpath(genpath('~/matlab/vistasoft'));
-       ```
-   Note that if you have installed additional Matlab packages (such as the RemoteDataToolbox), you will have to ensure that these packages are on your path as well.
+
+   ```matlab
+   addpath(genpath('~/matlab/vistasoft'));
+   ```
+
+Note that if you have installed additional Matlab packages (such as the RemoteDataToolbox), you will have to ensure that these packages are on your path as well.
 
 For help with the new mrInit intialization method, please see the [Initialization Page](http://white.stanford.edu/newlm/index.php/Initialization#mrInit).
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To install Vistasoft:
    addpath(genpath('~/matlab/vistasoft'));
    ```
 
-Note that if you have installed additional Matlab packages (such as the RemoteDataToolbox), you will have to ensure that these packages are on your path as well.
+   Note that if you have installed additional Matlab packages (such as the RemoteDataToolbox), you will have to ensure that these packages are on your path as well.
 
 For help with the new mrInit intialization method, please see the [Initialization Page](http://white.stanford.edu/newlm/index.php/Initialization#mrInit).
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ For detailed documentation, please visit the [VISTA lab wiki](http://vistalab.st
 ### Installation
 
 To install Vistasoft:
+
 1) Clone the Vistasoft repository on your local machine; for example:
    ```sh
    > cd ~/matlab

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ To install Vistasoft:
 
 For help with the new mrInit intialization method, please see the [Initialization Page](http://white.stanford.edu/newlm/index.php/Initialization#mrInit).
 
+### License
+
 (c) Vista lab, Stanford University.
 
 Unless otherwise noted, all our code is released under the [GPL](http://www.gnu.org/copyleft/gpl.html) 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ For detailed documentation, please visit the [VISTA lab wiki](http://vistalab.st
 ### Installation
 
 To install Vistasoft:
+
 1. Clone the Vistasoft repository on your local machine; for example:
    ```sh
    > cd ~/matlab

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ And in addition:
 - utilities
 - setup
 - tutorials 
-- external: functions written by others that we use as dependencies (see optional software).
+- external: functions written by others that we use as dependencies (see optional packages).
 
 ### External dependencies
 Vistasoft depends on the following packages:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 VISTASOFT is the main software repository of the [Vista lab](http://vistalab.stanford.edu) at [Stanford University](http://stanford.edu). It contains Matlab code to perform a variety of analysis on MRI data, including functional MRI and diffusion MRI.
 
-It has the following modules:
+### Modules
+Vistasoft contains the following modules:
 
 - mrAlign : Aligning functional and anatomical data
 - mrAnatomy: Handling anatomical MRI data. 
@@ -18,18 +19,34 @@ And in addition:
 - tutorials 
 - external: functions written by others that we use as dependencies (see optional software).
 
-External dependencies:
+### External dependencies
+Vistasoft depends on the following packages:
 - [Matlab](http://mathworks.com)
 - [SPM](http://www.fil.ion.ucl.ac.uk/spm/)
 
-Optional packages:
+### Optional Packages
  - [Freesurfer](https://surfer.nmr.mgh.harvard.edu/fswiki/DownloadAndInstall)
  - [FSL](http://fsl.fmrib.ox.ac.uk/fsl/fslwiki/)
  - [MRTrix](http://www.nitrc.org/projects/mrtrix/)
  - [JSONLab](http://iso2mesh.sourceforge.net/cgi-bin/index.cgi?jsonlab)
+ - [RemoteDataToolbox](https://github.com/isetbio/RemoteDataToolbox)
 
+### Documentation
 For detailed documentation, please visit the [VISTA lab wiki](http://vistalab.stanford.edu/wiki).
 
+### Installation
+
+To install Vistasoft:
+1) Clone the Vistasoft repository on your local machine; for example:
+   ```sh
+   > cd ~/matlab
+   > git clone https://github.com/vistalab/vistasoft
+   ```
+2) Start Matlab and Add the Vistasoft repository's base directory to your Matlab path:
+   ```matlab
+   addpath(genpath('~/matlab/vistasoft'));
+   ```
+   Note that if you have installed additional Matlab packages (such as the RemoteDataToolbox), you will have to ensure that these packages are on your path as well.
 
 For help with the new mrInit intialization method, please see the [Initialization Page](http://white.stanford.edu/newlm/index.php/Initialization#mrInit).
 

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ For detailed documentation, please visit the [VISTA lab wiki](http://vistalab.st
 To install Vistasoft:
 
 1. Clone the Vistasoft repository on your local machine; for example:
-      ```sh
-      > cd ~/matlab
-      > git clone https://github.com/vistalab/vistasoft
-      ```
+       ```sh
+       > cd ~/matlab
+       > git clone https://github.com/vistalab/vistasoft
+       ```
 2. Start Matlab and Add the Vistasoft repository's base directory to your Matlab path:
-      ```matlab
-      addpath(genpath('~/matlab/vistasoft'));
-      ```
+       ```matlab
+       addpath(genpath('~/matlab/vistasoft'));
+       ```
    Note that if you have installed additional Matlab packages (such as the RemoteDataToolbox), you will have to ensure that these packages are on your path as well.
 
 For help with the new mrInit intialization method, please see the [Initialization Page](http://white.stanford.edu/newlm/index.php/Initialization#mrInit).

--- a/README.md
+++ b/README.md
@@ -37,13 +37,12 @@ For detailed documentation, please visit the [VISTA lab wiki](http://vistalab.st
 ### Installation
 
 To install Vistasoft:
-
-1) Clone the Vistasoft repository on your local machine; for example:
+1. Clone the Vistasoft repository on your local machine; for example:
    ```sh
    > cd ~/matlab
    > git clone https://github.com/vistalab/vistasoft
    ```
-2) Start Matlab and Add the Vistasoft repository's base directory to your Matlab path:
+2. Start Matlab and Add the Vistasoft repository's base directory to your Matlab path:
    ```matlab
    addpath(genpath('~/matlab/vistasoft'));
    ```

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ For detailed documentation, please visit the [VISTA lab wiki](http://vistalab.st
 To install Vistasoft:
 
 1. Clone the Vistasoft repository on your local machine; for example:
-   ```sh
-   > cd ~/matlab
-   > git clone https://github.com/vistalab/vistasoft
-   ```
+      ```sh
+      > cd ~/matlab
+      > git clone https://github.com/vistalab/vistasoft
+      ```
 2. Start Matlab and Add the Vistasoft repository's base directory to your Matlab path:
-   ```matlab
-   addpath(genpath('~/matlab/vistasoft'));
-   ```
+      ```matlab
+      addpath(genpath('~/matlab/vistasoft'));
+      ```
    Note that if you have installed additional Matlab packages (such as the RemoteDataToolbox), you will have to ensure that these packages are on your path as well.
 
 For help with the new mrInit intialization method, please see the [Initialization Page](http://white.stanford.edu/newlm/index.php/Initialization#mrInit).


### PR DESCRIPTION
The old README contains no information about Installation, which, though perhaps obvious in this case, is usually included on the splash page of similar repositories. It's absence might confound Matlab newbies as well.

I also added the RemoteDataToolbox as optional software and reformatted a few of the sections to have headers.