### PR TITLE
Fixed a minor bug in which a bash shell is launched non-interactively…

### DIFF
--- a/tutorials/mesh/t_meshTemplate.m
+++ b/tutorials/mesh/t_meshTemplate.m
@@ -41,7 +41,7 @@ fs_home = getenv('FREESURFER_HOME');
 if isempty(fs_home)
     % sometimes, Matlab doesn't get the environment, but we can pull it out of
     % a system command like so:
-    [retval, output] = system('/bin/bash -c ''echo -n $FREESURFER_HOME''');
+    [retval, output] = system('/bin/bash -ci ''echo -n $FREESURFER_HOME''');
     if retval == 0, fs_home = output; end
 end
 if isempty(fs_home)
@@ -55,7 +55,7 @@ subjects_dir = getenv('SUBJECTS_DIR');
 if isempty(subjects_dir)
     % sometimes, Matlab doesn't get the environment, but we can pull it out of
     % a system command like so:
-    [retval, output] = system('/bin/bash -c ''echo -n $SUBJECTS_DIR''');
+    [retval, output] = system('/bin/bash -ci ''echo -n $SUBJECTS_DIR''');
     if retval == 0, fs_home = output; end
 end
 if isempty(subjects_dir)


### PR DESCRIPTION
… to grab the FREESURFER_HOME or SUBJECTS_DIR when they are not set in the matlab environment; the shell is now launched interactively, so should always read the bash_profile

This is a pretty minor change, but since it demonstrates how to correctly grab missing environment variables (from bash at least) when matlab is launched from the desktop instead of the console, I thought it worth pushing.