### PR TITLE
Read write tck

### DIFF
--- a/mrDiffusion/fiber/fg/fgExtract.m
+++ b/mrDiffusion/fiber/fg/fgExtract.m
@@ -147,20 +147,7 @@ inds = sort(inds(:),'descend')';
 if isfield(fg,'params') && ~isempty(fg.params)
   % Remove fg.params entries from the largest to smallest, thus
   % avoiding an index exceeds matrix dimensions error.
-  for kk = 1:numel(fg.params)
-    if ~isfield(fg.params{kk}, 'stat')
-      % Remove the fg.params entry that does not have a 'stat'
-      % field.
-      fg.params(kk) = [];
-      % Add 1 to the counter and set the entry in idx - which
-      % will keep track of which params we removed. This will be
-      % used in the next cell to loop over the pathwayInfo field
-      % and remove the corresponding entries in the pathwayInfo.
-      % fields.
-      % c = c+1;
-      % idx(c) = kk; %#ok<AGROW>
-    end
-  end
+  fg.params = [];
 end
 
 %% REMOVAL: fibers removed based on 'list' (inds)

--- a/mrDiffusion/fiber/fg/fgRead.m
+++ b/mrDiffusion/fiber/fg/fgRead.m
@@ -11,37 +11,34 @@ function fg = fgRead(fgFile)
 %
 % EXAMPLE:
 %   fgRead('fgName.mat');
+%   fgRead('fgName.pdb')
+%   fgRead('fgName.tck')
 % 
 % See Also:
 %   fgWrite.m
 % 
 % 
-% (C) Stanford VISTA, 2011
+% (C) Stanford VISTA, 2016
 
 %% Check inputs
-
 % Check for name variable and use fg.name if empty
 if ~exist('fgFile','var') || isempty(fgFile) 
-    fgFile = mrvSelectFile('r',{'pdb','mat'},'Select FG File'); 
+    fgFile = mrvSelectFile('r',{'pdb','mat','tck'},'Select FG File'); 
 end
 
 % Get the file type
-if strcmp(fgFile(end-3:end),'.mat')
-    type = 'mat';
-end
-
-if strcmp(fgFile(end-3:end),'.pdb')
-    type = 'pdb';
-end
-
+[~,~,fileType] = fileparts(fgFile);
 
 %% Read the file
-
-switch type
-    case 'pdb'
+switch fileType
+    case '.pdb'
         fg = mtrImportFibers(fgFile);
-    case 'mat'
+    case '.mat'
         fg = dtiLoadFiberGroup(fgFile);
+    case '.tck'
+        fg = dtiImportFibersMrtrix(fgFile);
+    otherwise
+        error('[%s] Cannot parse file type for the tractogram.',mfilename)
 end
 
 return

--- a/mrDiffusion/file/fibers/dtiWriteFiberGroup.m
+++ b/mrDiffusion/file/fibers/dtiWriteFiberGroup.m
@@ -18,6 +18,6 @@ if(~exist('versionNum','var') || isempty(versionNum))
   versionNum = 1.0;
 end
     
-save(fileName,'fg','versionNum','coordinateSpace');
+save(fileName,'fg','versionNum','coordinateSpace','-v7.3');
 
 return;


### PR DESCRIPTION
I added the functionality to read MRTRIX fibers directly from disk (.tck file extension). We tested this and seems to work. 

In addition, my local copy of the repository had also a couple of changes to the way fgExtract.m works. My group seems to be the only group (via LiFE) to be using fgExtract.m. If this change to fgExtract creates conflicts we can remove the change. Conflcits can in theory be introduced to the way Quench reads in fiber groups.