### PR TITLE
Fix minor bug: strcmp command checking that the file is a nifti file

### DIFF
--- a/mrDiffusion/roi/dtiRoiXformMrVistaVolRoi.m
+++ b/mrDiffusion/roi/dtiRoiXformMrVistaVolRoi.m
@@ -73,7 +73,7 @@ if  ~isfield(dt6,'xformVAnatToAcpc') || isempty(dt6.xformVAnatToAcpc)
     disp('Computing mrVista Xform');
     
     % compute the xform
-    if strcmp(vAnatomy(end-6:end),'ii.gz') 
+    if strcmp(vAnatomy(end-6:end),'.nii.gz') 
         vAnatomy         = niftiRead(vAnatomy);
         xformVAnatToAcpc = vAnatomy.qto_xyz;
         


### PR DESCRIPTION
`dtiRoiXformMrVistaVolRoi`, in checking that file is a nifti, 

calls:
`strcmp(vAnatomy(end-6:end),'ii.gz') `

should be: 
`strcmp(vAnatomy(end-6:end),'.nii.gz') `

