### PR TITLE
Fix bug. Edge case when we bootstrap only once

### DIFF
--- a/mrBOLD/Analysis/retinotopyModel/rmPlotCoverage.m
+++ b/mrBOLD/Analysis/retinotopyModel/rmPlotCoverage.m
@@ -418,7 +418,7 @@ if vfc.nboot>0
         otherwise
             error('Unknown method %s',vfc.method)
     end
-    RFcov=median(m)';
+    RFcov=median(m,1)';
     
 % no bootstrap
 else


### PR DESCRIPTION
Specify to make the median in the first dimension -- fixes a bug n the edge case of bootstrapping only once. 