### PR TITLE
Add isgraphics() to check the output of mrvNewGraphWin 

### DIFF
--- a/mrDiffusion/dwi/dwiGet.m
+++ b/mrDiffusion/dwi/dwiGet.m
@@ -363,7 +363,7 @@ switch(mrvParamFormat(param))
         % Apparently, this runs even if there is only one element in lst
         val = mean(val,4);
         
-    case {'b0image','b0valsimage','s0valsimage'}
+    case {'b0image','b0valsimage','s0valsimage','s0image'}
         % S0 = dwiGet(dwi,'b0 image',coords);
         % Return an S0 value for each voxel in coords
         % Coords are in the rows (i.e., nCoords x 3)

--- a/mrDiffusion/preprocess/dtiCheckMotion.m
+++ b/mrDiffusion/preprocess/dtiCheckMotion.m
@@ -38,7 +38,9 @@ t = vertcat(ec.xform(:).ecParams);
 % We make a plot of the motion correction during eddy current correction
 % but we do not show the figure. We only save it to disk.
 fh = mrvNewGraphWin([],[],visibility);
-fh = fh.Number; 
+if isgraphics(fh)
+    fh = fh.Number; 
+end
 
 subplot(2,1,1); 
 plot(t(:,1:3)); 


### PR DESCRIPTION
Previous versions of the code used isstruct() which crashed the dtiCheckMotion function. The previous pull request removed the if statement check. But there was probably a reason why there was a check (though it's not 100% clear to me why). 

isstruct() is replaced with isgraphics(), introduced in R2014b. The function will work on older versions of matlab if the graphics toolbox is installed. 