### PR TITLE
mrAnatExtractBrain.m: corrected bugs in calling FSL bet

### DIFF
--- a/mrAnatomy/Segment/mrAnatExtractBrain.m
+++ b/mrAnatomy/Segment/mrAnatExtractBrain.m
@@ -71,6 +71,12 @@ else
     end
 end
 
+% JB on 19/08/2016: on some systems, calling a system command outputs some text when running .bashrc or .cshrc
+remain=bet; % so we remove any additional starting lines 
+while ~isempty(remain) %if there are more than 2 lines
+  [bet,remain]=strtok(remain,sprintf('\n')); % isolate first line
+end
+
 bet = strtrim(bet); % The name of the bet funciton on the system
 
 % Set temporary file names for the out file and bet script. These will be
@@ -100,7 +106,7 @@ for ii=1:numel(betLevel)
     betOut = tempname;
     betCmd = [bet ' ' out ' ' betOut ' -mnf ' num2str(betLevel(ii))];
     fid = fopen(betScript,'wt');
-    fprintf(fid,'#!/bin/bash\nexport FSLOUTPUTTYPE=NIFTI_GZ\n%s\n',betCmd);
+    fprintf(fid,'#!/bin/bash\nFSLOUTPUTTYPE=NIFTI_GZ\n%s\n',betCmd);  %JB on 19/08/2016: should not export FSLOUTPUTTYPE: it has to equal NIFTI_GZ inside the script
     fclose(fid);
     unix([bash ' ' betScript]);
     betOut = [betOut '_mask.nii.gz'];


### PR DESCRIPTION
Hello, I've corrected two bugs when calling FSL BET. I'm not sure how specific this is to my particular Linux set-up, but I tried to make the fixes general.
- The first bug was that when Matlab uses system('which bet') to get the path to bet. On my system, any call to 'system' prints additional lines before the path to bet (they are printed by .cshrc, which is called by every call to 'system). These extra lines had to be removed. This would be the case for any user whose .cshrc or .bashrc normally prints to the terminal.
- the second bug is when calling bet and setting FSLOUTPUTTYPE to NIFTI_GZ. It seems that it is not necessary to export the environment variable to set the correct output format for this call to be. In fact exporting will change the default output type for the rest of the matlab session, which is not necessarily what the user wants.