### PR TITLE
Nifti

### DIFF
--- a/fileFilters/nifti/niftiRead.m
+++ b/fileFilters/nifti/niftiRead.m
@@ -56,6 +56,7 @@ else
 end
 
 % When there is a niftiGet, this can go away.
-ni.data_type = niftiClass2DataType(class(ni.data));
+% There now is a niftiGet. So it can go away.
+%  ni.data_type = niftiClass2DataType(class(ni.data));
 
 return

--- a/fileFilters/nifti/niftiWrite.m
+++ b/fileFilters/nifti/niftiWrite.m
@@ -3,88 +3,113 @@ function niftiWrite(ni,fName)
 %
 %   niftiWrite(ni,[fName])
 %
-% Uses the NIFTI-1 implementation in Matlab from Shen. 
+% Wrapper to writeFileNifti mex file, which writes a VISTASOFT nifti
+% structure to a NIFTI-1 file.
 % 
 % INPUTS
 %   ni - a nifti structure 
 %   fName - output file name  (defaults to ni.fname if empty). 
 % 
 % FILE FORMATS:
-%   Defaults to compressed '.nii.gz' format. If fName is set to
-%   [something]'.nii' then compression is not performmed as it is presumed
-%   that the user does not want the file to be compressed.
+%   fName extension should be either '.nii' or 'nii.gz'
 % 
 % EXAMPLE:
-%   ni = niftiRead('niftiFile.nii.gz');
-%   fName = 'myFile.nii.gz'
+%   dFolder = mrtInstallSampleData('functional','mrBOLD_01');
+%   pth =  fullfile(dFolder, 'Raw', 'T1_Inplane.nii.gz');
+%   ni  = niftiRead(pth);
+%   fName = fullfile(tempdir, 'myFile.nii.gz');
 %   niftiWrite(ni,fName);
-% 
-% See also:  niftiCreate, feWriteValues2nifti
+%
+% See also:  niftiRead
 % 
 % (C) Stanford VISTA, 2012-2015
 % 
 
-%% Set defaults
-compress = true;
-fname_supplied = false;
-
-
-%% Check inputs
-if nargin==0
-    help(mfilename)
-    return
-end
-
-if notDefined('fName')
-    fName = '';
-else
-    fname_supplied = true;
-end
-
-
-%% Check file extension
-
-% If no name was supplied check the nifti structure for the name
-if isempty(fName)
-    if isfield(ni,'fname') && ~isempty(ni.fname)
-        fName = ni.fname;
-    else
-        error('A filename is required to save a NIFTI-1 structure to file.');
-    end
-end
+if exist('fName', 'var') && ~isempty(fName)
+    ni.fname = fName;
     
-% Handle the file extension (must be '.nii' for save_nii)
-[p, f, e] = fileparts(fName);
-switch e
-    case '.gz'
-        fName = fullfile(p,f);
-    case '.nii'
-        % If a filename was passed in and it was something'.nii' then we
-        % assume the user does not want the file compressed.
-        if fname_supplied; compress = false; end
-    otherwise
-        fName = fullfile(p,[f '.nii']);
+    elseif ~isfield(ni,'fname') || isempty(ni.fname)
+    error('A filename is required to save a NIFTI-1 structure to file.');
 end
 
-
-%% Deal with old VISTASOFT nifti structures.
-if isfield(ni,'data')
-  % This is likely to be a old VISTASOFT nifti-1 structure, see
-  % niftiVista2ni.m
-  ni = niftiVista2ni(ni);
-end
-
-
-%% Save the file to disk using Shen's code.
-save_nii(ni,fName);
-
-
-%% GZip the file
-if compress
-    gzip(fName);
-     
-    % Delete the unzipped file created by save_nii.m:
-    delete(fName);
-end
+writeFileNifti(ni);
 
 return
+
+
+%% Old code
+% The old code was not a wrapper to writeFileNifti, but instead converted
+% the VISTASOFT nifti struct to a nifti-1 struct using the function
+% niftiVista2ni, and then write the nifti-1 struct to file using the Shen
+% function save_nii.
+%
+% We prefer the mex file writeFileNifti, which is fast which does the
+% inverse conversion of the mex function readFileNifti (wrapped in the m
+% file niftiRead).
+
+% %% Set defaults
+% compress = true;
+% fname_supplied = false;
+% 
+% 
+% %% Check inputs
+% if nargin==0
+%     help(mfilename)
+%     return
+% end
+% 
+% 
+% 
+% if notDefined('fName')
+%     fName = '';
+% else
+%     fname_supplied = true;
+% end
+% 
+% 
+% %% Check file extension
+% 
+% % If no name was supplied check the nifti structure for the name
+% if isempty(fName)
+%     if isfield(ni,'fname') && ~isempty(ni.fname)
+%         fName = ni.fname;
+%     else
+%         error('A filename is required to save a NIFTI-1 structure to file.');
+%     end
+% end
+%     
+% % Handle the file extension (must be '.nii' for save_nii)
+% [p, f, e] = fileparts(fName);
+% switch e
+%     case '.gz'
+%         fName = fullfile(p,f);
+%     case '.nii'
+%         % If a filename was passed in and it was something'.nii' then we
+%         % assume the user does not want the file compressed.
+%         if fname_supplied; compress = false; end
+%     otherwise
+%         fName = fullfile(p,[f '.nii']);
+% end
+% 
+% 
+% %% Deal with old VISTASOFT nifti structures.
+% if isfield(ni,'data')
+%   % This is likely to be a old VISTASOFT nifti-1 structure, see
+%   % niftiVista2ni.m
+%   ni = niftiVista2ni(ni);
+% end
+% 
+% 
+% %% Save the file to disk using Shen's code.
+% save_nii(ni,fName);
+% 
+% 
+% %% GZip the file
+% if compress
+%     gzip(fName);
+%      
+%     % Delete the unzipped file created by save_nii.m:
+%     delete(fName);
+% end
+% 
+% return

--- a/mrBOLD/GetSet/Nifti/niftiGet.m
+++ b/mrBOLD/GetSet/Nifti/niftiGet.m
@@ -51,10 +51,10 @@ switch param
         end
         
     case 'datatype'
-        if isfield(ni, 'data_type')
-            val = ni.data_type;
-        else
-            warning('vista:niftiError', 'No data_type information found in nifti. Returning empty');
+        if isfield(ni, 'data')
+            val = niftiClass2DataType(class(ni.data));
+        else            
+            warning('vista:niftiError', 'No data information found in nifti. Returning empty');
             val = [];
         end
         

--- a/mrBOLD/XformView/nifti2ROI.m
+++ b/mrBOLD/XformView/nifti2ROI.m
@@ -40,7 +40,7 @@ ni   = niftiApplyCannonicalXform(ni);
 % This is the map data
 data = niftiGet(ni, 'data');
 data = nifti2mrVistaAnat(data);
-
+data = round(data);
 % ensure data are integers
 assert(isequal(data, round(data)));
 


### PR DESCRIPTION
The main change to this branch is that the matlab function niftiWrite is now a wrapper to the mex function writeFileNifti.

There was a long off-line exchange about this issue with @francopestilli  and @rosemary-le, some of which is copied below.

Also, I ran mrvTest on this branch for BOLD data. All tests pass using Mac OS 10.12.2 and Matlab 2016b.

# EMAIL
After some poking around, here's what I understand:

Nifti files store space and time units as a single 6-bit number (first 3 bits for space, second 3 bits for time). Vistasoft uses a custom Matlab structured array when a nifti file is loaded into the workspace, which we generally refer to as a vistasoft nifti (or niiv, or 'Old VISTASOFT nifti-1 struct). This struct does not contain the standard nifti field 'xyzt_units', but instead uses two fields, 'xyz_units' and 'time_units'. All fine, except for one thing: vistasoft does not handle this conversion consistently.

Specifically, readFileNifti (a mex file) and niftiRead (a wrapper which just calls readFileNifti) populate the two units field ('xyz_units' and 'time_units') with strings (like 'mm' and 'sec') by correctly interpreting the field 'xyzt_units'. This is fine. The mex file writeFileNifti does the inverse: it reads the two string fields, 'xyz_units' and 'time_units' and correctly translates them into a 6-bit number, which it writes into the nifti file. 

Hence you can read a file with readFileNifti (or niftiRead) and then write it with writeFileNifti without changing it. 

All good. (And note that a nifti file does not store words like 'microns' or 'micron' or 'radians' - just the 6 bit number)

But here are the complications:

First, the function niftiWrite is not a wrapper for the mex function writeFileNifti. It never calls writeFileNifti. Instead, it calls a Matlab function which converts the vistasoft nifti to a nifti-1 struct (niftiVista2ni), and then writes the file with a Jimmy Shen function (save_nii). Unfortunately, the conversion function (niftiVista2ni) and the vistasoft mex function (writeFileNifti) do not handle units fields the same way. In particular, the function niftiVista2ni used to have these two bizarre lines:
nii.hdr.dime.xyzt_units          = niiv.xyz_units;
nii.hdr.dime.xyzt_units          = niiv.time_units;

The lines are bizarre because the second one simply overwrites the first one. Moreover this will result in nonsense if the vistasoft nifti was created by readFileNifti (or niftiRead), since these functions create units fields with text, and the nifti file we are trying to write wants a 6-bit integer, not text. It is for this reason that until recently, executing niftiRead followed by niftiWrite followed by niftiRead resulted in a change in units. 

Hence I changed the function niftiVista2ni a few months ago to try to correctly mimic writeFileNifti by converting the two text fields in a vistasoft nifti into a 6-bit integer. I might have made a mistake by using 'micron' somewhere instead of 'microns', or the reverse. Not sure.

But still another problem:

The two conversion functions, niftiVista2ni and niftiNi2Vista, are no longer inverses. The first one converts two text strings into a 6-bit integer. The second one simply copies the 6-bt integer into the two fields that are meant to have text:
niiv.xyz_units          = nii.hdr.dime.xyzt_units;
niiv.time_units         = nii.hdr.dime.xyzt_units;
I see a few solutions to clean up this mess:

Option 1 
(1) stop using niftiVista2ni and niftiNi2Vista
(2) stop calling save_nii
(3) make niftiWrite a wrapper for writeFileNifti

This way, niftiRead does the same as readFileNifti and niftiWrite does the same as writeFileNifti, and they (already) contain the inverse conversion process (nifti-1 <--> niiv)

Option 2
fix niftiNi2Vista so that it is the inverse of niftiVista2ni

Option 3
Add a switch to niftiVista2ni so that it can handle either a 6-bit integer or two text strings in a vistasoft nifti, and convert the strings (or copy the number) into the xyzt_units field

In any case, we should also make sure that other functions in vistasoft assume that vistasoft nifti's contain text strings and not 6 bit integers. AND we should make sure that any vistasoft function (other than mex files) that reads units from a nifti does so with niftiGet.

I can implement one of these later in the week.

Jon


#define NIFTI_UNITS_UNKNOWN 0
  858 #define NIFTI_UNITS_METER   1
  859 #define NIFTI_UNITS_MM      2
  860 #define NIFTI_UNITS_MICRON  3
  861 #define NIFTI_UNITS_SEC     8
  862 #define NIFTI_UNITS_MSEC   16
  863 #define NIFTI_UNITS_USEC   24
  864 #define NIFTI_UNITS_HZ     32
  865 #define NIFTI_UNITS_PPM    40
  866 #define NIFTI_UNITS_RADS   48
********************************************

# MRV TEST
```
Test suite: core
Test suite location: /Users/jonathanwinawer/matlab/toolboxes/vistasoft/mrTest/bold/core
24-Jan-2017 08:50:50


core

   test_Scripts
      test_Scripts .......................................... passed in     0.051010 seconds
   test_Scripts ............................................. passed in     0.067039 seconds


   test_Stats_fisherz
      test_Stats_fisherz .................................... passed in     0.287540 seconds
   test_Stats_fisherz ....................................... passed in     0.290302 seconds


   test_averagetSeries
      test_averagetSeries ................................... passed in    18.564172 seconds
   test_averagetSeries ...................................... passed in    18.568533 seconds


   test_betweenScansMotionComp
      test_betweenScansMotionComp ........................... passed in    44.445576 seconds
   test_betweenScansMotionComp .............................. passed in    44.463688 seconds


   test_corAnalFromInplane
      test_corAnalFromInplane ............................... passed in    11.945302 seconds
   test_corAnalFromInplane .................................. passed in    11.946622 seconds


   test_detrendTSeries
      test_detrendTSeries ................................... passed in     2.218267 seconds
   test_detrendTSeries ...................................... passed in     2.218668 seconds


   test_getCurDataROI
      test_getCurDataROI .................................... passed in    10.209067 seconds
   test_getCurDataROI ....................................... passed in    10.209445 seconds


   test_glm
      test_glm .............................................. passed in    42.962894 seconds
   test_glm ................................................. passed in    42.963219 seconds


   test_graphWin
      test_graphWin ......................................... passed in     0.058522 seconds
   test_graphWin ............................................ passed in     0.058822 seconds


   test_importNiftiROI
      test_importNiftiROI ................................... passed in    16.752685 seconds
   test_importNiftiROI ...................................... passed in    16.780935 seconds


   test_meanMapFromInplane
      test_meanMapFromInplane ............................... passed in    12.987273 seconds
   test_meanMapFromInplane .................................. passed in    12.987603 seconds


   test_mrInit
      test_mrInit ........................................... passed in     8.452557 seconds
   test_mrInit .............................................. passed in     8.452853 seconds


   test_mrvMigration
      test_mrvMigration ..................................... passed in    20.549194 seconds
   test_mrvMigration ........................................ passed in    20.569344 seconds


   test_niftiStruct
      test_niftiStruct ...................................... passed in     0.030345 seconds
   test_niftiStruct ......................................... passed in     0.030624 seconds


   test_normalizedMeanMapFromInplane
      test_normalizedMeanMapFromInplane ..................... passed in     9.989728 seconds
   test_normalizedMeanMapFromInplane ........................ passed in     9.990016 seconds


   test_plotMeanTSeries
      test_plotMeanTSeries .................................. passed in    10.091053 seconds
   test_plotMeanTSeries ..................................... passed in    10.091340 seconds


   test_prf
      test_prf .............................................. passed in    31.419253 seconds
   test_prf ................................................. passed in    31.419570 seconds


   test_tSeries4D
      test_tSeries4D ........................................ passed in     9.480147 seconds
   test_tSeries4D ........................................... passed in     9.480453 seconds


   test_viewGetHidden
      test_viewGetHidden .................................... passed in     9.569310 seconds
   test_viewGetHidden ....................................... passed in     9.569753 seconds


   test_viewGetInplane
      test_viewGetInplane ................................... passed in    12.535872 seconds
   test_viewGetInplane ...................................... passed in    12.536178 seconds


   test_withinScansMotionComp
      test_withinScansMotionComp ............................ passed in    46.586014 seconds
   test_withinScansMotionComp ............................... passed in    46.586299 seconds


   test_xformInplaneToVolume
      test_xformInplaneToVolume ............................. passed in    34.546137 seconds
   test_xformInplaneToVolume ................................ passed in    34.546441 seconds

core ........................................................ passed in   355.637430 seconds

-----------------------------------------
Environment information:
matlabVer: Bioinformatics Toolbox
matlabVer: Computer Vision System Toolbox
matlabVer: Control System Toolbox
matlabVer: Curve Fitting Toolbox
matlabVer: DSP System Toolbox
matlabVer: Database Toolbox
matlabVer: FieldTrip
matlabVer: Global Optimization Toolbox
matlabVer: Image Acquisition Toolbox
matlabVer: Image Processing Toolbox
matlabVer: Instrument Control Toolbox
matlabVer: MATLAB
matlabVer: MATLAB Coder
matlabVer: MATLAB Compiler
matlabVer: MATLAB Compiler SDK
matlabVer: MATLAB xUnit Test Framework
matlabVer: Mapping Toolbox
matlabVer: Neural Network Toolbox
matlabVer: Optimization Toolbox
matlabVer: Parallel Computing Toolbox
matlabVer: Partial Differential Equation Toolbox
matlabVer: Signal Processing Toolbox
matlabVer: Simulink
matlabVer: Simulink Control Design
matlabVer: Statistical Parametric Mapping
matlabVer: Statistics and Machine Learning Toolbox
matlabVer: Symbolic Math Toolbox
matlabVer: System Identification Toolbox
matlabVer: Wavelet Toolbox
matlabVer: Yokogawa MEG Reader toolbox for MATLAB
computer: MACI64
vistaDir: /Users/jonathanwinawer/matlab/toolboxes/vistasoft/mrBOLD
vistaVer: Unversioned directory

```
