### PR TITLE
updates to fix the 4th column of the transform matrix of inplane nift…

### DIFF
--- a/fileFilters/freesurfer/fs_tkreg2vista.m
+++ b/fileFilters/freesurfer/fs_tkreg2vista.m
@@ -1,0 +1,62 @@
+function vistaAlignment = fs_tkreg2vista(R, func, anat)
+%
+% Test:
+% pth = '/Volumes/server/Projects/Retinotopy/wl_subj042/20170713_PrismaPilot';
+% func = fullfile(pth,'preproc/distort/unwarp/distortion_averaged_corrected.nii.gz');
+% anat = fullfile(pth, '3DAnatomy/t1.nii.gz');
+% R = [...
+%    9.998847842216492e-01 1.509265881031752e-02 -1.660096342675388e-03 -1.650448679924011e+00 
+%    5.567267071455717e-03 -2.626409232616425e-01 9.648773074150085e-01 -2.170687866210938e+01
+%    -1.412637531757355e-02 9.647750854492188e-01 2.626940906047821e-01 6.907639980316162e+00
+%    0 0 0 1];
+% vistaAlignment = fs_tkreg2vista(R, func, anat)
+
+% Get the functional transform from voxels to TKR
+ni.f    = niftiRead(func);
+f.dim   = niftiGet(ni.f, 'dim');
+f.res   = niftiGet(ni.f, 'pixdim');
+Tf      = vox2ras_tkreg(f.dim, f.res);
+
+% Get the anatomical transform from voxels to TKR
+ni.a    = niftiRead(anat);
+a.dim   = niftiGet(ni.a, 'dim');
+a.res   = niftiGet(ni.a, 'pixdim');
+Ta      = vox2ras_tkreg(a.dim, a.res);
+
+% Compute the transform Q0, from anatomy to functional data in freesurfer
+% space. (Note that FS matrices are 0 indexed.)
+Q0 = inv(Tf)*R*Ta;
+
+% Compute the transform Q1, Q0 transformed for 1-indexing
+xform0to1 = [[eye(3); zeros(1,3)] ones(4,1)];
+Q1 = xform0to1 * Q0 * inv(xform0to1);
+
+% Get the transforms used by vistasoft to re-orient nifti files (both
+% inplane - ie functional - and anatomical)
+f2v      = niftiCreateXform(ni.f,'inplane');
+[~, a2v] = niftiApplyCannonicalXform(ni.a);
+
+% Get the additional transform used by vistasoft to transform the nifti
+% anatomical (RAS) to a 3D matlab array (IPR)
+aRAS2IPR = [...
+    0 0 -1 a.dim(3)+1
+    0 -1 0 a.dim(2)+1
+    1 0 0 0
+    0 0 0 1];
+
+% Combine the two anatomical transforms into 1
+a2v = round(aRAS2IPR * a2v); 
+
+% put it all together: (from right to left): 
+%       vista anatomical (IPR) => 
+%       native anatomical => 
+%       native functional =>
+%       vista functional
+
+a2f = f2v  * Q1 * inv(a2v);
+
+% and the inverse, which is what vistasoft stores
+f2a = inv(a2f);
+vistaAlignment = f2a;
+
+end

--- a/fileFilters/nifti/niftiApplyXform.m
+++ b/fileFilters/nifti/niftiApplyXform.m
@@ -96,14 +96,14 @@ end
 if (~isempty(niftiGet(nii,'freqdim')) && niftiGet(nii,'freqdim'))
     nii = niftiSet(nii,'freqdim', dimOrder(niftiGet(nii,'freqdim')));
 else
-    warning('No freqdim field set in the nifti. Assuming freqdim = 1. Nifti stored at: %s', niftiGet(nii,'FName'));
+    fprintf('No freqdim field set in the nifti. Assuming freqdim = 1. Nifti stored at: %s\n', niftiGet(nii,'FName'));
     nii = niftiSet(nii,'freqdim', 1);
 end
 
 if (~isempty(niftiGet(nii,'phasedim')) && niftiGet(nii,'phasedim'))
     nii = niftiSet(nii,'phasedim', dimOrder(niftiGet(nii,'phasedim')));
 else
-    warning('No phasedim field set in the nifti. Assuming phasedim = 2. Nifti stored at: %s', niftiGet(nii,'FName'));
+    fprintf('No phasedim field set in the nifti. Assuming phasedim = 2. Nifti stored at: %s\n', niftiGet(nii,'FName'));
     nii = niftiSet(nii,'phasedim', 2);
 end
 

--- a/fileFilters/nifti/niftiCreateXform.m
+++ b/fileFilters/nifti/niftiCreateXform.m
@@ -61,7 +61,14 @@ switch xformType
         vectorFrom = niftiCurrentOrientation(nii);
         vectorTo   = niftiCreateStringInplane(vectorFrom,sliceDim);
         xform      = niftiCreateXformBetweenStrings(vectorFrom,vectorTo);
-        
+
+        % check which dimensions have flips (rows with a -1), and then set
+        % the 4th column appropriately
+        isflipped = sum(xform(1:3,1:3),2) < 0;     
+        dim = niftiGet(nii, 'dim');
+        xform(isflipped,4) = dim(isflipped) + 1;   % set the 4th column of flipped rows to dim+1
+        xform(~isflipped,4) = 0;                   % Set the 4th column of nonflipped rows to 0
+                
     otherwise
         warning('vista:niftiError','The supplied transform type was unrecognized. Please try again. Returning empty transform.');
         return

--- a/mrBOLD/File/loadAnat.m
+++ b/mrBOLD/File/loadAnat.m
@@ -31,7 +31,7 @@ case 'Inplane',
     if ~exist(pathStr,'file')
         error(['No file at the location: ',pathStr]);
     else
-        ip = orientInplane(vw, pathStr);
+        %ip = orientInplane(vw, pathStr);
         vw = viewSet(vw,'Anat Initialize',pathStr);
     end
     


### PR DESCRIPTION
…is, after transforming them from their native space to the preferred vistasoft space (PRS, or closest possible to that; see niftiCreateXform comments)

Previously, every time an inplane is loaded in mrVista, a transform is applied to re-orient the inplane to PRS, or as close as possible given some constraints (see niftiCreateXform comments). This worked fine, but the 4th column of the transform matrix was computed incorrectly. As far as I know, this column was not used for anything, and was not written to disk, so it went unnoticed and caused no problems. However, I have now written a function that makes use of the full transform matrix of the re-oriented inplanes, and it is important that the numbers are correct. 

All mrv tests pass on the new branch.

Test suite: core
Test suite location: /Users/jonathanwinawer/matlab/toolboxes/vistasoft/mrTest/bold/core
25-Jul-2017 13:56:27


core

   test_Scripts
      test_Scripts .......................................... passed in     0.011468 seconds
   test_Scripts ............................................. passed in     0.014541 seconds


   test_Stats_fisherz
      test_Stats_fisherz .................................... passed in     0.123370 seconds
   test_Stats_fisherz ....................................... passed in     0.125786 seconds


   test_averagetSeries
      test_averagetSeries ................................... passed in    28.635488 seconds
   test_averagetSeries ...................................... passed in    28.638660 seconds


   test_betweenScansMotionComp
      test_betweenScansMotionComp ........................... passed in    39.111806 seconds
   test_betweenScansMotionComp .............................. passed in    39.113839 seconds


   test_corAnalFromInplane
      test_corAnalFromInplane ............................... passed in     9.592628 seconds
   test_corAnalFromInplane .................................. passed in     9.594746 seconds


   test_detrendTSeries
      test_detrendTSeries ................................... passed in     3.071134 seconds
   test_detrendTSeries ...................................... passed in     3.071511 seconds


   test_exportNiftiParameterMap
      test_exportNiftiParameterMap .......................... passed in    66.075055 seconds
   test_exportNiftiParameterMap ............................. passed in    66.075429 seconds


   test_getCurDataROI
      test_getCurDataROI .................................... passed in     9.595936 seconds
   test_getCurDataROI ....................................... passed in     9.596297 seconds


   test_glm
      test_glm .............................................. passed in    40.006683 seconds
   test_glm ................................................. passed in    40.007021 seconds


   test_graphWin
      test_graphWin ......................................... passed in     0.040526 seconds
   test_graphWin ............................................ passed in     0.040845 seconds


   test_importNiftiROI
      test_importNiftiROI ................................... passed in    13.411167 seconds
   test_importNiftiROI ...................................... passed in    13.411505 seconds


   test_installSegmentation
      test_installSegmentation .............................. passed in    54.603548 seconds
   test_installSegmentation ................................. passed in    54.603899 seconds


   test_meanMapFromInplane
      test_meanMapFromInplane ............................... passed in    10.056304 seconds
   test_meanMapFromInplane .................................. passed in    10.056902 seconds


   test_meshView
      test_meshView ......................................... passed in    52.220594 seconds
   test_meshView ............................................ passed in    52.220927 seconds


   test_mrInit
      test_mrInit ........................................... passed in     8.366215 seconds
   test_mrInit .............................................. passed in     8.366512 seconds


   test_mrvBuildMesh
      test_mrvBuildMesh ..................................... passed in    13.089503 seconds
   test_mrvBuildMesh ........................................ passed in    13.089835 seconds


   test_mrvConvertVAnat
      test_mrvConvertVAnat .................................. passed in     8.467147 seconds
   test_mrvConvertVAnat ..................................... passed in     8.467481 seconds


   test_mrvMigration
      test_mrvMigration ..................................... passed in    18.057602 seconds
   test_mrvMigration ........................................ passed in    18.057958 seconds


   test_niftiStruct
      test_niftiStruct ...................................... passed in     0.014814 seconds
   test_niftiStruct ......................................... passed in     0.015085 seconds


   test_normalizedMeanMapFromInplane
      test_normalizedMeanMapFromInplane ..................... passed in     9.227151 seconds
   test_normalizedMeanMapFromInplane ........................ passed in     9.227442 seconds


   test_plotMeanTSeries
      test_plotMeanTSeries .................................. passed in    10.170883 seconds
   test_plotMeanTSeries ..................................... passed in    10.171159 seconds


   test_prf
      test_prf .............................................. passed in    24.598650 seconds
   test_prf ................................................. passed in    24.599352 seconds


   test_tSeries4D
      test_tSeries4D ........................................ passed in     9.569723 seconds
   test_tSeries4D ........................................... passed in     9.570177 seconds


   test_viewGetHidden
      test_viewGetHidden .................................... passed in     8.979862 seconds
   test_viewGetHidden ....................................... passed in     8.980221 seconds


   test_viewGetInplane
      test_viewGetInplane ................................... passed in    13.718023 seconds
   test_viewGetInplane ...................................... passed in    13.718342 seconds


   test_withinScansMotionComp
      test_withinScansMotionComp ............................ passed in    43.498342 seconds
   test_withinScansMotionComp ............................... passed in    43.498625 seconds


   test_xformInplaneToVolume
      test_xformInplaneToVolume ............................. passed in    30.616536 seconds
   test_xformInplaneToVolume ................................ passed in    30.616884 seconds

core ........................................................ passed in   526.114327 seconds

-----------------------------------------
Environment information:
matlabVer: Bioinformatics Toolbox
matlabVer: Computer Vision System Toolbox
matlabVer: Control System Toolbox
matlabVer: Curve Fitting Toolbox
matlabVer: DSP System Toolbox
matlabVer: Database Toolbox
matlabVer: Global Optimization Toolbox
matlabVer: Image Acquisition Toolbox
matlabVer: Image Processing Toolbox
matlabVer: Instrument Control Toolbox
matlabVer: MATLAB
matlabVer: MATLAB Coder
matlabVer: MATLAB Compiler
matlabVer: MATLAB Compiler SDK
matlabVer: MATLAB xUnit Test Framework
matlabVer: Mapping Toolbox
matlabVer: Neural Network Toolbox
matlabVer: Optimization Toolbox
matlabVer: Parallel Computing Toolbox
matlabVer: Partial Differential Equation Toolbox
matlabVer: Signal Processing Toolbox
matlabVer: Simulink
matlabVer: Simulink Control Design
matlabVer: Statistical Parametric Mapping
matlabVer: Statistics and Machine Learning Toolbox
matlabVer: Symbolic Math Toolbox
matlabVer: System Identification Toolbox
matlabVer: Wavelet Toolbox
computer: MACI64
vistaDir: /Users/jonathanwinawer/matlab/toolboxes/vistasoft/mrBOLD
gitOrigin: https://github.com/vistalab/vistasoft.git
gitchecksum: b951a6e067a0c17bd81f1e33325ce13c0238bfac
