### PR TITLE
ROI threshold should be rescaled regardless of sign

### DIFF
--- a/mrDiffusion/GUI/dtiFiberUI.m
+++ b/mrDiffusion/GUI/dtiFiberUI.m
@@ -2054,10 +2054,8 @@ if(length(thresh)==1), thresh = [thresh inf]; end
 colors = 'gcbmry';
 flags = {'fillHoles'};
 if(removeSatellites), flags{end+1} = 'removeSatellites'; end
-if(any(thresh<0))
-    thresh = (abs(thresh)-valRange(1))./diff(valRange);
-    fprintf('actual thresh: %0.3f (valRange = [%0.2f,%0.2f])', thresh(1), valRange(1), valRange(2));
-end
+thresh = (thresh-valRange(1))./diff(valRange);
+fprintf('actual thresh: %0.3f (valRange = [%0.2f,%0.2f])', thresh(1), valRange(1), valRange(2));
 for(ii=2:length(thresh))
     if(length(thresh)>2)
         newRoi = dtiNewRoi([baseName '_' num2str(round(thresh(ii-1)*100),'%03d')], colors(mod(ii-2,length(colors))+1));


### PR DESCRIPTION
When creating an ROI by masking an image, the user is prompted for upper and lower thresholds. If either of these are negative, the code rescales them to match the image data. However:

- The rescaling looks incorrect to me. If the image has a value range of -5 to 5 and the user specifies bounds of -5 and 0, taking the absolute value (as performed currently) will result in rescaled bounds of [1,0.5], rather than [0,0.5].
- It seems to me that the rescaling needs to be performed regardless of sign. Otherwise bounds of 2 and 5 will not be rescaled, while the image is mapped from [-5,5] to [0,1], resulting in nothing.

This small PR fixes both of those issues.