### PR TITLE
Update dtiImportFibersMrtrix.m

### DIFF
--- a/fileFilters/mrtrix/dtiImportFibersMrtrix.m
+++ b/fileFilters/mrtrix/dtiImportFibersMrtrix.m
@@ -54,7 +54,8 @@ try
     % be two possible keywords for this field.
     numIndx = strmatch('num_tracks:',header);
     if(isempty(numIndx))
-        numIndx = strmatch('count:',header); 
+        numIndx = strmatch('count:',header);
+        numIndx = max(numIndx);
         n = str2double(header{numIndx}(7:end));
     else
         n = str2double(header{numIndx}(12:end));


### PR DESCRIPTION
Original code expected one "counts:" field in a mrtrix .tck header.  This is problematic when using the mrtrix command cat_tracks to combine .tcks, which appends an additional "counts:" field to the end of the .tck header. Change is to just grab the max index and passing that through.