### PR TITLE
Update dtiRoiToImg.m

### DIFF
--- a/mrDiffusion/roi/dtiRoiToImg.m
+++ b/mrDiffusion/roi/dtiRoiToImg.m
@@ -33,7 +33,7 @@ if(~exist('imgXform','var')||isempty(imgXform))
 end
 
 sz = diff(ceil(mrAnatXformCoords(inv(imgXform), bb)))+1;
-roiImg = false(sz);
+roiImg = false(abs(sz));
 % Remove coords outside the bounding box
 badCoords = coords(:,1)<bb(1,1) | coords(:,1)>bb(2,1) ...
           | coords(:,2)<bb(1,2) | coords(:,2)>bb(2,2) ...


### PR DESCRIPTION
per Dan Bullock (git user DanNBullock), use of false() as a means of getting an array of zeros on sz resulted in an empty dimension when a negative is passed in. The previous structure seemed to be predicated on a presumption of either RAS or LPI. Use of Abs(sz) ensures that the actual dimensions are passed.