### PR TITLE
Fix hidden view to be consistent with volume view

### DIFF
--- a/mrBOLD/Analysis/DataManagement/getCurData.m
+++ b/mrBOLD/Analysis/DataManagement/getCurData.m
@@ -24,8 +24,9 @@ if strcmp(viewGet(vw,'View Type'),'Volume') || strcmp(viewGet(vw,'View Type'),'G
     volSize = viewGet(vw,'Size');
     tmp = tmp{scanNum}(:);
     data = NaN*ones(volSize);
-    volIndices = coords2Indices(viewGet(vw,'Coords'),volSize);
-    data(volIndices) = tmp;
+    volCoords = viewGet(vw,'Coords');
+    volIndices = coords2Indices(volCoords,volSize);
+    data(volIndices) = tmp; 
 else
     data = tmp{scanNum};
 end

--- a/mrBOLD/GetSet/View/viewGetSession.m
+++ b/mrBOLD/GetSet/View/viewGetSession.m
@@ -193,11 +193,24 @@ switch param
                 val = viewGet(vw,'anatsize');
             case {'Volume','Gray','generalGray'}
                 if isfield(vw, 'anat')
+                    % In the GUI this field is populated so we get it
                     if ~isempty(vw.anat), val = viewGet(vw,'Anat Size'); end
                 end
+                % If it is a hidden volume view then this field is not
+                % populated so we need to load the anatomy image in order
+                % to calculate it's size
                 if ~exist('val','var') || isempty(val)
                     pth = getVAnatomyPath; % assigns it if it's not set
-                    [~, val] = readVolAnatHeader(pth);
+                    % Here we load the volume anatomy - Note that we need
+                    % to apply this transform between the dimensions of the
+                    % raw image and the mrvista coordinates
+                    val = size(readVolAnat(pth));
+                    
+                    % This was the original call but we note that the
+                    % function nifti2mrVistaAnat applies a transform to the
+                    % data that makes the data dimensions different from
+                    % those in the header. 
+                    % [~, val] = readVolAnatHeader(pth);
                 end
             case 'Flat'
                 val = [vw.ui.imSize,2];


### PR DESCRIPTION
When a volume is read in the hidden volume view it is read in a different way than in the 3D view window. This causes the data to have a different size. This fix makes it so that the same transform is applied in the hidden view as the main view. BUT we are not sure which is the bug and which is the correct way to read the data. Someone with a deep knowledge of the mrVista coordinate system should take a look and confirm what is going on. @jyeatman was not sure