### PR TITLE
make niftiMontage.m compatible with the volume parameter in niftiView.m

### DIFF
--- a/fileFilters/nifti/niftiMontage.m
+++ b/fileFilters/nifti/niftiMontage.m
@@ -26,6 +26,7 @@ function [m, hdl] = niftiMontage(imVol, varargin)
 
 %% Handle the Inputs
 p = inputParser;
+p.KeepUnmatched=true;
 vFunc = @(x)(isnumeric(imVol) || exist(imVol,'file'));
 p.addRequired('imVol',vFunc);
 


### PR DESCRIPTION
When using niftiView with the 'volume' option niftiMontage fails. niftiView passes all the parameters to niftiMontage, but niftiMontage does not have the 'volume' parameter. With the fix p.KeepUnmatched=true it ignores it and it does not throw an error. 