### PR TITLE
Add functions enabling .tck export compatible with MRTrix3 MRView

### DIFF
--- a/fileFilters/mrtrix/dtiExportFibersMrtrix3.m
+++ b/fileFilters/mrtrix/dtiExportFibersMrtrix3.m
@@ -1,0 +1,92 @@
+function tck = dtiExportFibersMrtrix3(fg, tck_filename)
+%
+%   tck = dtiExportFibersMrtrix3(fg, tck_filename) 
+%
+%   Saves a FG structure to disk in MRTRIX format (.tck)
+%
+% INPUTS:
+%     fg -           vistasoft fiber group structure
+%     tck_filename - file path to output .ick
+% 
+% OUTPUT:
+%     tck - reconstructed TCK file structure. 
+%
+%   Based on MATLAB functions distributed with mrtrix 0.3
+%
+% This function is a modification of dtiExportFibersMrtrix.m, by incorportating header information of MRTrix 3 .tck format ("mrtrix tracks"). 
+%
+% Written by Hiromasa Takemura, CiNet BIT 2020 August 
+% 
+
+% initialize output
+tck = dtiGetFgParams(fg);
+
+% transpose the streamline order
+tck.data = fg.fibers';
+
+for ii = 1:length(tck.data)
+    % transpose the node order
+    tck.data{ii} = tck.data{ii}';
+
+end
+clear ii
+
+% save the file w/ mrtrix fxn
+write_mrtrix_fibers(tck, tck_filename);
+
+return
+end
+
+%%%%%%%%%%%%%%%%%%%%%%
+% AUXILIARY FUNCTION %
+%%%%%%%%%%%%%%%%%%%%%%
+function write_mrtrix_fibers (fibers, filename)
+%
+% function: write_mrtrix_fibers (fibers, filename)
+%
+% writes the track data stored as a cell array in the 'data' field of the
+% fibers variable to the MRtrix format track file 'filename'. All other fields
+% of the fibers variable will be written as text entries in the header, and are
+% expected to supplied as character arrays.
+%
+% 
+% This function was originally distributed with mrtrix 0.2/0.3
+
+if ~isfield (fibers, 'data')
+  disp ('ERROR: input fibers variable does not contain required ''data'' field');
+  return;
+end
+
+if ~iscell (fibers.data)
+  disp ('ERROR: input fibers.data variable should be a cell array');
+  return;
+end
+
+f = fopen (filename, 'w', 'ieee-le');
+if (f < 1) 
+  disp (['error opening ' filename ]);
+  return;
+end
+
+fprintf (f, 'mrtrix tracks\ndatatype: Float32LE\ncount: %d\n', prod(size(fibers.data)));
+names = fieldnames(fibers);
+for i=1:size(names)
+  if strcmpi (names{i}, 'data'), continue; end
+  if strcmpi (names{i}, 'count'), continue; end
+  if strcmpi (names{i}, 'datatype'), continue; end
+  fprintf (f, '%s: %s\n', names{i}, getfield(fibers, names{i}));
+end
+fprintf (f, '%s: %s\n', 'timestamp: ', num2str(now)); % This allows visualizing the streamlines in mrview
+data_offset = ftell (f) + 20;
+fprintf (f, 'file: . %d\nEND\n', data_offset);
+
+fwrite (f, zeros(data_offset-ftell(f),1), 'uint8');
+for i = 1:prod(size(fibers.data))
+  fwrite (f, fibers.data{i}', 'float32');
+  fwrite (f, [ nan nan nan ], 'float32');
+end
+
+fwrite (f, [ inf inf inf ], 'float32');
+fclose (f);
+
+end

--- a/mrDiffusion/fiber/fg/fgWrite.m
+++ b/mrDiffusion/fiber/fg/fgWrite.m
@@ -13,7 +13,8 @@ function fgWrite(fg,name,type)
 %             'pdb'    - quench file format [DEFAULT]
 %             'quench' - same as 'pdb'                      
 %             'mat'    - matlab file format
-%             'tck'    - MRTRIX file format (also 'mrtrix'/'.tck')
+%             'tck'    - MRTRIX3 file format (also 'mrtrix'/'.tck')
+%	      'tck2'   - MRTRIX version 0.2 file format
 %
 %          * If "name" ends in either .pdb or .mat the correct file type
 %            will be used.
@@ -69,6 +70,8 @@ switch type
     case 'mat'
         dtiWriteFiberGroup(fg, name);
     case {'tck', 'mrtrix', '.tck'}
+        dtiExportFibersMrtrix3(fg, name);
+    case {'tck2'}
         dtiExportFibersMrtrix(fg, name);
 end
 


### PR DESCRIPTION
_Overview of the problem_

Original version of code (dtiExportFibersMrtrix.m) was written on the basis of older version of MRTrix 0.2. Therefore, exported .tck file is not compatible with MRTrix3's MRView. 

_Proposed solution at this point_
We figured out that header information of .tck file is not identical between MRTrix 0.2 and MRTrix3. Specifically, header "mrtrix fibers" becomes "mrtrix tracks" in MRTrix3. I made minimum change in dtiExportFibersMrtrix.m incorporating this header change, and created a new function (dtiExportFibersMrtrix3.m) supporting .tck export for MRTrix3. 

I confirmed that we could load .tck file exported from fg structure in vistasoft in MRView (of MRTrix3) using this function. 

_What will happen after this change_
As you see in edits on fgWrite.m, the default output of tck file will become compatible with MRTrix3, not MRTrix 0.2 after merging this commit. Original function supporting MRTrix0.2 remains, and can be used if you specified type of exporting format as "tck2", in fgWtite.m function. 

Therefore, I am making newest version of .tck as default, while keeping the option to export older file format in fgWrite.  