### PR TITLE
Ek css range fix

### DIFF
--- a/mrBOLD/Analysis/retinotopyModel/rmDefineParameters.m
+++ b/mrBOLD/Analysis/retinotopyModel/rmDefineParameters.m
@@ -186,6 +186,7 @@ end
 switch lower(params.analysis.pRFmodel{1})
     case {'onegaussiannonlinear' 'css' 'onegaussiannonlinearboxcar' 'cssboxcar'}
         params.analysis.nonlinear = true;
+        params.analysis.fixcssexp = 0;
 end
         
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/mrBOLD/Analysis/retinotopyModel/rmPlotTwoParams.m
+++ b/mrBOLD/Analysis/retinotopyModel/rmPlotTwoParams.m
@@ -157,15 +157,21 @@ for b=binvector(:)'
         ii2 = find(data.x==b);
         data.y(ii2) = s.mean;
         data.ysterr(ii2) = s.sterr;
-        data.y_bconf(ii2,:) = local_BootstrapBin(roi.(p2)(bii),roi.varexp(bii));
-        
+        if numel(roi.(p2)(bii))>1
+            data.y_bconf(ii2,:) = local_BootstrapBin(roi.(p2)(bii),roi.varexp(bii));
+        else
+            data.y_bconf(ii2,:) = repmat(roi.(p2)(bii),[1 3]);
+        end
     else
        fprintf(1,'[%s]:Warning:No data in %s %.1f to %.1f.\n',...
             mfilename,p1,b-binsize./2,b+binsize./2);
     end
 end
 if any(isnan(data.y_bconf))
-    data.y_bconf = [];
+    nanidx = any(isnan(data.y_bconf),2);
+    data.y_bconf(nanidx,:) = [];
+    data.x_bconf = data.x;
+    data.x_bconf(nanidx,:) = [];
 end
 
 
@@ -193,7 +199,7 @@ if plotFlag==1,
     if exist('bootstrp','file') 
         
         e = diff(data.y_bconf,[],2);
-        errorbar(data.x,data.y_bconf(:,2),e(:,1),e(:,2),'ko',...
+        errorbar(data.x_bconf,data.y_bconf(:,2),e(:,1),e(:,2),'ko',...
             'MarkerFaceColor','k',...
             'MarkerSize',MarkerSize);
         plot(data.xfit_bconf,data.yfit_bconf(:,2),'k','LineWidth',2);

--- a/mrBOLD/Analysis/retinotopyModel/rmSearchFit_range.m
+++ b/mrBOLD/Analysis/retinotopyModel/rmSearchFit_range.m
@@ -85,19 +85,21 @@ elseif isfield(model,'s2')
     range.upper(4,:) = ones(size(range.upper(3,:))).*params.analysis.sigmaRatioInfVal;
 end
 
-if isfield(model, 'exp')
-    fieldnum=size(range.start, 1)+1;
-    range.start(fieldnum,:) = model.exp;
-    gridExps_unique=unique(params.analysis.exp);
-    gridExps=[min(gridExps_unique).*ones(expandRange,1); gridExps_unique; max(gridExps_unique).*ones(expandRange,1)];
-    gridExps=double(gridExps);
-    gridExps_matrix  = gridExps_unique(:)*ones(1,size(range.start,2));
-    startExps_matrix = ones(size(gridExps_matrix,1),1)*range.start(fieldnum,:);
-    [tmp, closestvalue] = sort(abs(gridExps_matrix-startExps_matrix));
-    closestvalue    = closestvalue(1,:)+expandRange;
-
-    range.upper(fieldnum,:) = gridExps(closestvalue+2);%expandRange);
-    range.lower(fieldnum,:) = gridExps(closestvalue-2);%expandRange);
+if isfield(model, 'exponent') && ~isempty(regexp(model.desc,'nonlinear','ONCE'))
+    % [ERK: Nov 16, 2021]: We start with exponents from grid fit or fixed 
+    % value. We restrict exponent range to be between 0-1, as we want it to 
+    % be a compressive nonlinear summation. (Values larger than one would
+    % cause an exponential increase of the pRF response). This change is 
+    % related to a bug fix on July 9 2019, (commit 976d397dcd4..) and
+    % reverses this section of code. 
+    range.start(4,:) = model.exponent;
+    range.lower(4,:) = range.lower(3,:)*0 + 0.01;
+    range.upper(4,:) = range.upper(3,:)*0 + 1;
+    
+    % [ERK]: Because sigma is affected by the exponent, we will give it
+    % room to change.
+    range.lower(3,:) = range.lower(3,:)*0;
+    range.upper(3,:) = range.upper(3,:)*0 + params.analysis.maxRF;
 end
 
 % reset stopping criteria relative to rawrss

--- a/mrTest/bold/extended/test_prf_full.m
+++ b/mrTest/bold/extended/test_prf_full.m
@@ -34,7 +34,6 @@ storedPRF = mrtGetValididationData('prfFull');
 % val.coordsSz   = length(coords);
 % save(vFile, '-struct', 'val')
 
-
 %% Retain original directory, change to data directory
 curDir = pwd;
 cd(dataDir);
@@ -60,33 +59,57 @@ vw = loadROI(vw, 'RV1.mat', 3, [], 0, 1);
 vw = rmMain(vw,'RV1.mat' ,5,'min pRF size', 0.5, 'max pRF size', 3,...
     'number of sigmas', 6, 'outerlimit', 0, ...
     'coarse sample', false, 'decimate', 0);
+mGauss = load(viewGet(vw, 'rm file'));
 
-m = load(viewGet(vw, 'rm file'));
-
-coords = rmGet(m.model{1}, 'roiindices');
-ecc = rmCoordsGet('gray', m.model{1}, 'ecc', coords);
-sig = rmCoordsGet('gray', m.model{1}, 'sigma', coords);
-x   = rmCoordsGet('gray', m.model{1}, 'x', coords);
-ve  = rmCoordsGet('gray', m.model{1}, 've', coords);
+coords = rmGet(mGauss.model{1}, 'roiindices');
+eccGauss = rmCoordsGet('gray', mGauss.model{1}, 'ecc', coords);
+sigGauss = rmCoordsGet('gray', mGauss.model{1}, 'sigma', coords);
+xGauss   = rmCoordsGet('gray', mGauss.model{1}, 'x', coords);
+veGauss  = rmCoordsGet('gray', mGauss.model{1}, 've', coords);
 %% Return to original directory
 cd(curDir)
 
 %% Validate the results
 tol = 1e-4;
 
-assertEqual(storedPRF.roiname,rmGet(m.model{1}, 'roiname'));
+assertEqual(storedPRF.roiname,rmGet(mGauss.model{1}, 'roiname'));
 
 assertEqual(storedPRF.coordsSz, length(coords));
 
-assertElementsAlmostEqual(storedPRF.eccmn, nanmean(ecc), 'relative', tol);
+assertElementsAlmostEqual(storedPRF.eccmn, nanmean(eccGauss), 'relative', tol);
 
-assertElementsAlmostEqual(storedPRF.sigmn, nanmean(sig), 'relative', tol);
+assertElementsAlmostEqual(storedPRF.sigmn, nanmean(sigGauss), 'relative', tol);
 
-assertElementsAlmostEqual(storedPRF.xmax, max(x), 'relative', tol);
+assertElementsAlmostEqual(storedPRF.xmax, max(xGauss), 'relative', tol);
 
-assertElementsAlmostEqual(storedPRF.vemax, max(ve), 'relative', tol);
+assertElementsAlmostEqual(storedPRF.vemax, max(veGauss), 'relative', tol);
 
 mrvCleanWorkspace;
+
+%% Test CSS pRF model separately
+% [ERK 11/17/21]: While one can request multiple models within one command
+% using the variable input 'pRFModel',{'onegaussian','css'}, here we test
+% the css model separately as it avoids getting exponents fixed to 1. This
+% is because the rmDefineParameters.m function only defines parameters
+% based on the first model ('one gaussian', not the second 'css').
+vw = rmMain(vw,'RV1.mat' ,5,'min pRF size', 0.5, 'max pRF size', 3,...
+    'number of sigmas', 6, 'outerlimit', 0, ...
+    'coarse sample', false, 'decimate', 0, 'pRFModel',{'css'});
+mCSS = load(viewGet(vw, 'rm file'));
+
+coords = rmGet(mCSS.model{1}, 'roiindices');
+
+% Check if css exponent ranges between 0-1.
+expCSS  = rmCoordsGet('gray', mCSS.model{1}, 'exponent', coords);
+assert(min(expCSS)>=0);
+assert(max(expCSS)<=1);
+
+%% TO DO: Store PRF results and compare against current output %%
+eccCSS = rmCoordsGet('gray', mCSS.model{1}, 'ecc', coords);
+sigCSS = rmCoordsGet('gray', mCSS.model{1}, 'sigma', coords);
+xCSS   = rmCoordsGet('gray', mCSS.model{1}, 'x', coords);
+veCSS  = rmCoordsGet('gray', mCSS.model{1}, 've', coords);
+
 
 %% End Script
 


### PR DESCRIPTION
Pull request to merge code with two bug fixes: 
* Define parameter flag related to Gari's recent fixcssexp flag.
* Clamp range of exponent to [0 1] in rmSearch fit for nonlinear Gausssian pRF model (CSS)