### PR TITLE
Mrmesh dev

### DIFF
--- a/mrMesh/tcpToolbox/pnet_readMsg.m
+++ b/mrMesh/tcpToolbox/pnet_readMsg.m
@@ -21,9 +21,7 @@ function msg = pnet_readMsg(con)
 msg = [];
 
 % Don't wait forever before aborting:
-if ispc, pnet(con,'setreadtimeout',4);
-else     pnet(con,'setreadtimeout',2);
-end
+pnet(con,'setreadtimeout',4);
 
 % The header and trailer are each 8 bytes long
 hdr = pnet(con,'read',8,'char');

--- a/mrMesh/tcpToolbox/pnet_readMsg.m
+++ b/mrMesh/tcpToolbox/pnet_readMsg.m
@@ -21,7 +21,9 @@ function msg = pnet_readMsg(con)
 msg = [];
 
 % Don't wait forever before aborting:
-pnet(con,'setreadtimeout',4);
+if ispc, pnet(con,'setreadtimeout',4);
+else     pnet(con,'setreadtimeout',2);
+end
 
 % The header and trailer are each 8 bytes long
 hdr = pnet(con,'read',8,'char');


### PR DESCRIPTION
I use MATLAB R2020b on a M1 MacbookPro with Rosetta, and the wine hq app (https://www.winehq.org/) to open ./mrMesh/meshserver/mrMeshSrv.exe. (See also my response to this issue: https://github.com/vistalab/vistasoft/issues/264).

The function "mrMesh/tcpToolbox/pnet_readMsg.m" kills the server if the wait time is too short.
I get the error message in the MATLAB command window below:

```
meshVisualize(vw.mesh{1})
mrmInitMesh: Add mesh actor...
Warning: could not read msg header.  Header length 0
 
> In pnet_readMsg (line 31)
In mrMesh (line 128)
In mrmSet (line 247)
In mrmInitMesh (line 29)
In meshVisualize (line 43) 
Warning: Error receiving server reply header. 
> In mrMesh (line 131)
In mrmSet (line 247)
In mrmInitMesh (line 29)
In meshVisualize (line 43) 
Warning: could not read msg header.  Header length 0
 
> In pnet_readMsg (line 31)
In mrMesh (line 70)
In mrmSet (line 389)
In mrmInitMesh (line 30)
In meshVisualize (line 43) 
Error using mrMesh (line 73)
Error receiving handshake reply.  Message length 0

Error in mrmSet (line 389)
         mrMesh(host, windowID, 'enable_origin_arrows', p);

Error in mrmInitMesh (line 30)
mrmSet(msh,'origin lines',0);

Error in meshVisualize (line 43)
[msh, lights] = mrmInitMesh(msh,backColor);
```

I fixed error by increasing the setreadtimeout from 2 to 4, for the "else" statement in vistasoft/mrMesh/tcpToolbox/pnet_readMsg.m (lines 24-26):
```
% Don't wait forever before aborting:
if ispc, pnet(con,'setreadtimeout',4);
else     pnet(con,'setreadtimeout',4);
end
```

As this makes the if statement obsolete, I changed it into a single line command:
```
% Don't wait forever before aborting:
pnet(con,'setreadtimeout',4);
```
